### PR TITLE
Updated package.json to use latest jsfmt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-jsfmt",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "`gulp` task for `jsfmt`",
   "keywords": [
     "gulpplugin",


### PR DESCRIPTION
Could not use esformatter plugins without updating jsfmt (plugins got support in esformatter v0.2.0).
gulp-jsfmt tests still passing after the change.
