### PR TITLE
Add formatJSON support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,31 @@ gulp.task('default', function() {
 });
 ```
 
+### format()
+Formats js (not JSON) files
+```js
+var gulp = require('gulp');
+var jsfmt  = require('gulp-jsfmt');
+
+gulp.task('default', function() {
+  gulp.src('./**/*.js')
+    .pipe(jsfmt.format())
+    .pipe(gulp.dest('./dist'));
+});
+```
+### formatJSON()
+Formats json (not JS) files
+```js
+var gulp = require('gulp');
+var jsfmt  = require('gulp-jsfmt');
+
+gulp.task('default', function() {
+  gulp.src('./**/*.json')
+    .pipe(jsfmt.formatJSON())
+    .pipe(gulp.dest('./dist'));
+});
+```
+
 #### `matches`
 Each patterns specified will be used to call `jsfmt.search`, and the results are passed back in the property named `matches` in each of the `Vinyl` object in the stream.
 

--- a/index.js
+++ b/index.js
@@ -3,3 +3,4 @@
 exports.rewrite = require('./lib/rewrite');
 exports.search = require('./lib/search');
 exports.format = require('./lib/format');
+exports.formatJSON = require('./lib/formatJSON');

--- a/lib/fmt.js
+++ b/lib/fmt.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = function fmt(buffer,config,formatter) {
+  var contents = buffer.toString(),
+  formattedContents;
+
+  formattedContents = formatter(contents, config);
+
+  return new Buffer(formattedContents.toString());
+};

--- a/lib/formatJSON.js
+++ b/lib/formatJSON.js
@@ -12,7 +12,8 @@ module.exports = function() {
   return through.obj(function(file, _, cb) {
     if (file.isBuffer()) {
       file.contents = fmt(file.contents,config,jsfmt.formatJSON);
-    } else if (file.isStream()) {
+    }
+    else if (file.isStream()) {
       file.contents = file.contents.pipe(new BufferStreams(function(err, buf, cb) {
         cb(null, fmt(buf,config,jsfmt.formatJSON));
       }));

--- a/lib/formatJSON.js
+++ b/lib/formatJSON.js
@@ -3,18 +3,18 @@
 var jsfmt = require('jsfmt');
 var through = require('through2');
 var BufferStreams = require('bufferstreams');
+var fmt   = require('./fmt');
 var util = require('./util');
-var fmt = require('./fmt');
 
 module.exports = function() {
   var config = jsfmt.getConfig();
 
   return through.obj(function(file, _, cb) {
     if (file.isBuffer()) {
-      file.contents = fmt(file.contents,config,jsfmt.format);
+      file.contents = fmt(file.contents,config,jsfmt.formatJSON);
     } else if (file.isStream()) {
       file.contents = file.contents.pipe(new BufferStreams(function(err, buf, cb) {
-        cb(null, fmt(buf,config,jsfmt.format));
+        cb(null, fmt(buf,config,jsfmt.formatJSON));
       }));
 
     }

--- a/test/formatJSON_test.js
+++ b/test/formatJSON_test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/*jshint multistr:true*/
+/*globals describe,it */
+
+var es = require('event-stream');
+var through = require('through2');
+var gutil = require('gulp-util');
+var jsfmt = require('../');
+
+describe('formatJSON', function() {
+
+  var unformattedJSON = '{\
+ "fieldname":    "value",\
+     "second field"   :[1,2,3,4]\
+  }';
+  var formattedJSON = '{\n  "fieldname": "value",\n  "second field": [1, 2, 3, 4]\n}';
+
+  it('should work in buffer mode with json', function(done) {
+    var stream = jsfmt.formatJSON(unformattedJSON),
+      n = 0;
+
+    stream.pipe(through.obj(function(file, _, cb) {
+      file.contents.toString().should.eql(formattedJSON);
+      this.push(file);
+      n++;
+      cb();
+    }, function(cb) {
+      n.should.eql(1);
+      cb();
+      done();
+    }));
+
+    stream.write(new gutil.File({
+      contents: new Buffer(unformattedJSON)
+    }));
+    stream.end();
+  });
+
+  it('should work in stream mode with json', function(done) {
+    var stream = jsfmt.formatJSON();
+
+    stream.once('data', function(file) {
+      file.isStream().should.eql(true);
+      file.contents.pipe(es.wait(function(err, data) {
+        data.toString().should.eql(formattedJSON);
+        done();
+      }));
+    });
+
+    stream.write(new gutil.File({
+      contents: es.readArray([unformattedJSON])
+    }));
+  });
+
+});


### PR DESCRIPTION
I wanted to use this plugin to also format JSON files, and the jsfmt.format call expects JS, not JSON.  In short, I've done this
- refactored the ```fmt``` function in lib/format.js to lib/fmt.js
- created a new lib/formatJSON.js file
- required lib/fmt in both lib/format and lib/formatJSON
- then pass either jsfmt.format or jsfmt.formatJSON to fmt() as 'formatter'

I added a test and very small README doc update for format/formatJSON